### PR TITLE
Updated docker-compose to use prebuild Splunk image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,16 @@
 version: '3'
 services:
   splunk:
-    build: ./splunk 
-    image: simdata-splunk
+    image: ${SPLUNK_IMAGE:-splunk/splunk:latest}
+    container_name: simdata-splunk
     ports:
       - 8000:8000
       - 8088:8088
       - 8089:8089
     environment:
-      SPLUNK_START_ARGS: "--accept-license --answer-yes  --seed-passwd changeme"
-      SPLUNK_USER: "root"
+      - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_HEC_TOKEN=00112233-4455-6677-8899-AABBCCDDEEFF
+      - SPLUNK_PASSWORD=changeme
   simdata:
     depends_on:
       - "splunk"

--- a/simdata-example/webserver.json
+++ b/simdata-example/webserver.json
@@ -75,7 +75,7 @@
     {
       "name": "SplunkHEC",
       "config": {
-        "uri": "http://splunk:8088",
+        "uri": "https://splunk:8088",
         "token": "00112233-4455-6677-8899-AABBCCDDEEFF",
         "default_index": "default"
       }


### PR DESCRIPTION
This docker-compose will now always use the latest version of Splunk, 
configured with internal Ansible script.

Furthermore, simdata now uses HTTPS for HEC